### PR TITLE
Import optimizations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,4 @@ gem 'riiif', '~> 1.1'
 gem 'solargraph'
 gem 'colorize'
 gem 'rubyzip'
+gem "ruby-vips", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -690,6 +690,8 @@ GEM
       multipart-post
       oauth2
     ruby-progressbar (1.10.1)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
     samvera-nesting_indexer (2.0.0)
@@ -843,6 +845,7 @@ DEPENDENCIES
   rsolr (>= 1.0)
   rspec-rails
   rspec-sidekiq
+  ruby-vips (~> 2.0)
   rubyzip
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/lib/hydra/derivatives/processors/pdf_processor.rb
+++ b/lib/hydra/derivatives/processors/pdf_processor.rb
@@ -1,0 +1,65 @@
+require 'mini_magick'
+
+module Hydra
+  module Derivatives
+    module Processors
+      class PdfProcessor < Processor
+        class_attribute :timeout
+
+        def process
+          timeout ? process_with_timeout : create_resized_image
+        end
+
+        def process_with_timeout
+          Timeout.timeout(timeout) { create_resized_image }
+        rescue Timeout::Error
+          raise Hydra::Derivatives::TimeoutError, "Unable to process image derivative\nThe command took longer than #{timeout} seconds to execute"
+        end
+
+        protected
+
+          # When resizing images, it is necessary to flatten any layers, otherwise the background
+          # may be completely black. This happens especially with PDFs. See #110
+          def create_resized_image
+            create_image do |xfrm|
+              if size
+                xfrm.flatten
+                xfrm.resize(size.to_f)
+              end
+            end
+          end
+
+          def create_image
+            xfrm = load_and_select_layer
+            yield(xfrm) if block_given?
+            xfrm.quality(quality.to_s) if quality
+            write_image(xfrm)
+          end
+
+          def write_image(xfrm)
+            output_io = StringIO.new
+            q = quality ? quality : 100
+            format = directives.fetch(:format)
+            output_io.puts xfrm.write_to_buffer ".#{format}", {Q: q}
+            output_io.rewind
+            output_file_service.call(output_io, directives)
+          end
+
+        private
+
+          def size
+            directives.fetch(:size, nil)
+          end
+
+          def quality
+            directives.fetch(:quality, nil)
+          end
+
+          def load_and_select_layer
+            Vips::Image.new_from_file source_path, page: directives.fetch(:layer, 0)
+            #Vips::Image.pdfload(source_path, page: directives.fetch(:layer, 0))
+          end
+      end
+    end
+  end
+end

--- a/lib/hydra/derivatives/processors/pdf_processor.rb
+++ b/lib/hydra/derivatives/processors/pdf_processor.rb
@@ -1,5 +1,3 @@
-require 'mini_magick'
-
 module Hydra
   module Derivatives
     module Processors
@@ -13,7 +11,7 @@ module Hydra
         def process_with_timeout
           Timeout.timeout(timeout) { create_resized_image }
         rescue Timeout::Error
-          raise Hydra::Derivatives::TimeoutError, "Unable to process image derivative\nThe command took longer than #{timeout} seconds to execute"
+          raise Hydra::Derivatives::TimeoutError, "Unable to process pdf derivative\nThe command took longer than #{timeout} seconds to execute"
         end
 
         protected
@@ -57,7 +55,6 @@ module Hydra
 
           def load_and_select_layer
             Vips::Image.new_from_file source_path, page: directives.fetch(:layer, 0)
-            #Vips::Image.pdfload(source_path, page: directives.fetch(:layer, 0))
           end
       end
     end

--- a/lib/hydra/derivatives/runners/pdf_derivatives.rb
+++ b/lib/hydra/derivatives/runners/pdf_derivatives.rb
@@ -1,0 +1,11 @@
+require_relative '../processors/pdf_processor'
+
+module Hydra
+  module Derivatives
+    class PdfDerivatives < ImageDerivatives
+      def self.processor_class
+	Processors::PdfProcessor
+      end
+    end
+  end
+end


### PR DESCRIPTION
Discussion
============
The import of large PDF's is painfully slow.  Tracking this down to MiniMagick and ImageMagick.  PDF processing is painful with IM.   LibVips is much more performant.  It requires an additional lib install on the host machine libvips.

In this MR
=========
* Monkey patches runner for PDF works to defer to a new processor
* Adds PDF processor based on libvips