### PR TITLE
Handle searching

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -145,7 +145,7 @@ class CatalogController < ApplicationController
       all_names = config.show_fields.values.map(&:field).join(' ')
       title_name = solr_name('title', :stored_searchable)
       field.solr_parameters = {
-        qf: "#{all_names} file_format_tesim all_text_timv handle_sim",
+        qf: "#{all_names} file_format_tesim all_text_timv handle_sim handle_suffix_sim",
         pf: title_name.to_s
       }
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -145,7 +145,7 @@ class CatalogController < ApplicationController
       all_names = config.show_fields.values.map(&:field).join(' ')
       title_name = solr_name('title', :stored_searchable)
       field.solr_parameters = {
-        qf: "#{all_names} file_format_tesim all_text_timv",
+        qf: "#{all_names} file_format_tesim all_text_timv handle_sim",
         pf: title_name.to_s
       }
     end

--- a/app/indexers/csu_indexer.rb
+++ b/app/indexers/csu_indexer.rb
@@ -8,4 +8,9 @@ class CsuIndexer < Hyrax::WorkIndexer
   # this behavior
   include Hyrax::IndexesLinkedMetadata
 
+  def generate_solr_document
+    super.tap do |solr_doc|
+      solr_doc['handle_suffix_sim'] = object.handle_suffix
+    end
+  end
 end

--- a/app/models/csu_metadata.rb
+++ b/app/models/csu_metadata.rb
@@ -102,6 +102,12 @@ module CsuMetadata
     property :embargo_terms, predicate: ::RDF::Vocab::DC.description, multiple: false
   end
 
+  def handle_suffix
+    return nil if handle.blank?
+
+    handle.map{ |url| url.split('/')[-1]}
+  end
+
   protected
 
   def update_fields

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,6 +34,10 @@ class SolrDocument
     self[Solrizer.solr_name('handle')]
   end
 
+  def handle_suffix
+    self[Solrizer.solr_name('handle_suffix')]
+  end
+
   def campus
     self[Solrizer.solr_name('campus')]
   end


### PR DESCRIPTION
Enables searching for the handle, both by the full url and just the handle id (suffix)

![Image 2020-07-01 at 3 09 58 PM](https://user-images.githubusercontent.com/5492162/86297770-0a061e00-bbb1-11ea-8087-c281c13a07bf.png)
