### PR TITLE
Fix saving of embargos and leases on updates

### DIFF
--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -205,6 +205,8 @@ module Hyrax
         def apply_lease(env, intention)
           return true unless intention.wants_lease?
           env.curation_concern.apply_lease(*intention.lease_params)
+          env.curation_concern.lease.save # see https://github.com/samvera/hydra-head/issues/226
+
           # apply_lease returns true if there has been a change in the lease period,
           # otherwise it returns nil.  Since we want to continue processing, even when the date
           # does not change, we return true from this method.
@@ -215,6 +217,7 @@ module Hyrax
         def apply_embargo(env, intention)
           return true unless intention.wants_embargo?
           env.curation_concern.apply_embargo(*intention.embargo_params)
+          env.curation_concern.embargo.save # see https://github.com/samvera/hydra-head/issues/226
           # apply_embargo returns true if there has been a change in the embargo period,
           # otherwise it returns nil.  Since we want to continue processing, even when the date
           # does not change, we return true from this method.


### PR DESCRIPTION
This fixes #43 and may fix #44. I tested both, but I'm not sure I'm reproducing 44 correctly. Note that these saves are present in the 2.x version of this actor.  They do get removed in the 3.x version, but that's after the way things are saved as a whole is modified.